### PR TITLE
fix: 修正dev release版本号和标题问题，为deb包添加MIT协议

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,25 +44,13 @@ jobs:
           echo "$HOME/go/bin" >> $GITHUB_PATH
       - name: Make scripts executable
         run: |
-          chmod +x scripts/build-deb.sh scripts/build-rpm.sh scripts/windows/build-windows.sh
+          chmod +x scripts/build-deb.sh scripts/build-rpm.sh scripts/windows/build-windows.sh scripts/derive-version.sh
 
       - name: Derive version (tag -> release, main -> x.y.(z+1)-dev.date.hash)
         id: version
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          else
-            LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-            BASE_VER=${LATEST_TAG#v}
-            if [[ -z "$BASE_VER" || "$BASE_VER" == "$LATEST_TAG" ]]; then BASE_VER="0.0.0"; fi
-            # Increment patch version (z+1)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VER"
-            PATCH=$((PATCH + 1))
-            NEXT_VER="${MAJOR}.${MINOR}.${PATCH}"
-            DATE=$(date -u +%Y%m%d)
-            HASH=${GITHUB_SHA::7}
-            VERSION="${NEXT_VER}-dev.${DATE}.${HASH}"
-          fi
+          VERSION=$(bash scripts/derive-version.sh)
+          echo "Final version: ${VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       
       - name: Frontend build (inject version)
@@ -126,23 +114,14 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force --prune
 
+      - name: Make scripts executable
+        run: chmod +x scripts/build-macos.sh scripts/derive-version.sh
+
       - name: Derive version (tag -> release, main -> x.y.(z+1)-dev.date.hash)
         id: version
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          else
-            LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-            BASE_VER=${LATEST_TAG#v}
-            if [[ -z "$BASE_VER" || "$BASE_VER" == "$LATEST_TAG" ]]; then BASE_VER="0.0.0"; fi
-            # Increment patch version (z+1)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VER"
-            PATCH=$((PATCH + 1))
-            NEXT_VER="${MAJOR}.${MINOR}.${PATCH}"
-            DATE=$(date -u +%Y%m%d)
-            HASH=${GITHUB_SHA::7}
-            VERSION="${NEXT_VER}-dev.${DATE}.${HASH}"
-          fi
+          VERSION=$(bash scripts/derive-version.sh)
+          echo "Final version: ${VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
@@ -197,33 +176,40 @@ jobs:
     needs: [build-linux-windows, build-macos]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch tags
+        run: git fetch --tags --force --prune
+
+      - name: Make scripts executable
+        run: chmod +x scripts/derive-version.sh
+
       - name: Derive release metadata (tag -> release, main -> dev-latest)
         id: meta
         run: |
+          VERSION=$(bash scripts/derive-version.sh)
+          
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
             TAG="${GITHUB_REF_NAME}"
             PRERELEASE=false
             NAME="Release ${VERSION}"
           else
-            LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-            BASE_VER=${LATEST_TAG#v}
-            if [[ -z "$BASE_VER" || "$BASE_VER" == "$LATEST_TAG" ]]; then BASE_VER="0.0.0"; fi
-            # Increment patch version (z+1)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VER"
-            PATCH=$((PATCH + 1))
-            NEXT_VER="${MAJOR}.${MINOR}.${PATCH}"
-            DATE=$(date -u +%Y%m%d)
-            HASH=${GITHUB_SHA::7}
-            VERSION="${NEXT_VER}-dev.${DATE}.${HASH}"
             TAG="dev-latest"
             PRERELEASE=true
-            NAME="Dev ${VERSION}"
+            NAME="Development Build ${VERSION}"
           fi
+          
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+          
+          echo "Release metadata:"
+          echo "  Version: ${VERSION}"
+          echo "  Tag: ${TAG}"
+          echo "  Prerelease: ${PRERELEASE}"
+          echo "  Name: ${NAME}"
 
       - name: Remove previous dev release/tag
         if: ${{ steps.meta.outputs.tag == 'dev-latest' }}

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -65,11 +65,14 @@ trap 'mv -f "$BACKUP_WAILS_JSON" wails.json 2>/dev/null || true' EXIT
 [[ -f build/bin/${APP_NAME} ]] || { echo "Executable missing"; exit 1; }
 
 rm -rf "${DEB_DIR}"
-mkdir -p "${DEB_DIR}/DEBIAN" "${DEB_DIR}/usr/bin" "${DEB_DIR}/usr/share/applications" "${DEB_DIR}/usr/share/icons/hicolor/256x256/apps" "${DEB_DIR}/usr/share/pixmaps"
+mkdir -p "${DEB_DIR}/DEBIAN" "${DEB_DIR}/usr/bin" "${DEB_DIR}/usr/share/applications" "${DEB_DIR}/usr/share/icons/hicolor/256x256/apps" "${DEB_DIR}/usr/share/pixmaps" "${DEB_DIR}/usr/share/doc/${APP_NAME}"
 
 install -m 0755 build/bin/${APP_NAME} "${DEB_DIR}/usr/bin/${APP_NAME}"
 install -m 0644 assets/icons/appicon-256.png "${DEB_DIR}/usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png"
 install -m 0644 assets/icons/appicon-256.png "${DEB_DIR}/usr/share/pixmaps/${APP_NAME}.png"
+
+# Install license and copyright information
+install -m 0644 LICENSE "${DEB_DIR}/usr/share/doc/${APP_NAME}/copyright"
 
 # Generate desktop entry on the fly (avoid missing template path in CI)
 cat > "${DEB_DIR}/usr/share/applications/half-beat.desktop" << 'EOF'
@@ -98,6 +101,7 @@ Description: 基于 B站 API 的音乐播放器，实现你的「听视频」自
  Half-Beat-Player 是一款轻量的音乐播放器，采用 Wails v2 构建。
  支持 B 站扫码登录、BV 号解析、收藏夹导入、歌单管理等功能。
 Homepage: https://github.com/Sheyiyuan/Half-Beat-Player
+License: MIT
 EOF
 
 cat > "${DEB_DIR}/DEBIAN/postinst" << 'EOF'

--- a/scripts/derive-version.sh
+++ b/scripts/derive-version.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Derive version for builds
+# Usage: derive-version.sh
+# Outputs: version string to stdout
+
+set -euo pipefail
+
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+    # For tagged releases, use the tag name (remove 'v' prefix)
+    VERSION="${GITHUB_REF_NAME#v}"
+    echo "Tagged release version: ${VERSION}" >&2
+else
+    # For dev builds, increment patch version from latest tag
+    echo "Deriving dev version..." >&2
+    
+    # Get latest tag
+    LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1 || echo "")
+    echo "Latest tag: ${LATEST_TAG:-none}" >&2
+    
+    BASE_VER=${LATEST_TAG#v}
+    
+    # Handle case where no tags exist or tag format is invalid
+    if [[ -z "$BASE_VER" || "$BASE_VER" == "$LATEST_TAG" ]]; then 
+        echo "No valid tags found, using base version 0.0.0" >&2
+        BASE_VER="0.0.0"
+    fi
+    
+    # Parse version components more robustly
+    if [[ $BASE_VER =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        MAJOR=${BASH_REMATCH[1]}
+        MINOR=${BASH_REMATCH[2]}
+        PATCH=${BASH_REMATCH[3]}
+        echo "Parsed base version: ${MAJOR}.${MINOR}.${PATCH}" >&2
+    else
+        echo "Invalid version format in tag, using 0.0.0" >&2
+        MAJOR=0
+        MINOR=0
+        PATCH=0
+    fi
+    
+    # Increment patch version for dev builds
+    PATCH=$((PATCH + 1))
+    NEXT_VER="${MAJOR}.${MINOR}.${PATCH}"
+    
+    # Add dev suffix with date and commit hash
+    DATE=$(date -u +%Y%m%d)
+    HASH=${GITHUB_SHA::7}
+    VERSION="${NEXT_VER}-dev.${DATE}.${HASH}"
+    
+    echo "Generated dev version: ${VERSION}" >&2
+fi
+
+echo "${VERSION}"


### PR DESCRIPTION
- 统一版本号生成逻辑，使用derive-version.sh脚本
- 修复dev版本号解析，使用正则表达式更稳健地处理版本组件
- 改进release标题：正式版本用'Release'，开发版本用'Development Build'
- 为deb包添加MIT许可证信息到control文件和/usr/share/doc目录
- 增强版本号生成的错误处理和日志输出