### PR TITLE
fix: unblock 1.3.0 preview packaging

### DIFF
--- a/.github/BUILD.md
+++ b/.github/BUILD.md
@@ -92,7 +92,7 @@ Makefile 调用 `scripts/` 中的平台实现；Linux 上的 Wails 包装器会�
    - 需要在 GitHub Secrets 中配置证书
 3. **依赖要求**：
 
-   - 所有构建需要 Go 1.22+
+   - 常规构建需要 Go 1.22+；macOS 打包需要 Go 1.24+ 以生成 Mach-O `LC_UUID`
    - 前端构建需要 Node.js 22.13+ 和 pnpm 11.4.0
 
 ## 自定义配置

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          # Go 1.24+ emits LC_UUID for internally linked Mach-O binaries.
+          go-version: '1.24.x'
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -172,6 +173,12 @@ jobs:
         run: |
           go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
           echo "$HOME/go/bin" >> $GITHUB_PATH
+
+      - name: Verify Wails CLI Mach-O metadata
+        run: |
+          WAILS_BIN="$(go env GOPATH)/bin/wails"
+          "$WAILS_BIN" version
+          dwarfdump --uuid "$WAILS_BIN" | grep -q '^UUID:'
 
       - name: Build macOS (universal)
         run: make package-macos VERSION='${{ steps.version.outputs.version }}' CLEAN=1

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -3,7 +3,7 @@
 ## 系统要求
 - macOS 12+（Intel/Apple Silicon）
 - Xcode Command Line Tools
-- Wails CLI v2.11.0, Go 1.22+, Node.js 20+, pnpm 11.4.0, `create-dmg`
+- Wails CLI v2.11.0, Go 1.24+, Node.js 22.13+, pnpm 11.4.0, `create-dmg`
 
 ## 构建
 ```bash
@@ -26,4 +26,5 @@ make package-macos VERSION=1.2.0 CLEAN=1
 
 ## 常见问题
 - `wails` 未找到：确认已安装并在 PATH（或放在 `$HOME/go/bin`）
+- `missing LC_UUID load command`：确认 Wails CLI 和应用均使用 Go 1.24+ 构建
 - 缺少 `create-dmg`：通过 `brew install create-dmg` 安装

--- a/scripts/verify-linux-packages.sh
+++ b/scripts/verify-linux-packages.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ARTIFACT_ROOT=${1:-artifacts}
+ARTIFACT_ROOT=$(cd "$ARTIFACT_ROOT" && pwd)
 DEB_PATH=$(find "$ARTIFACT_ROOT" -type f -name '*.deb' -print -quit)
 RPM_PATH=$(find "$ARTIFACT_ROOT" -type f -name '*.rpm' -print -quit)
 
@@ -10,7 +11,7 @@ RPM_PATH=$(find "$ARTIFACT_ROOT" -type f -name '*.rpm' -print -quit)
 
 docker run --rm \
   -v "$(dirname "$DEB_PATH"):/packages:ro" \
-  debian:bookworm-slim \
+  debian:trixie-slim \
   sh -euc '
     apt-get update
     apt-get install -y "/packages/'"$(basename "$DEB_PATH")"'"

--- a/scripts/windows/smoke-test-installer.ps1
+++ b/scripts/windows/smoke-test-installer.ps1
@@ -38,9 +38,10 @@ try {
         throw "DisplayVersion is $displayVersion, expected $expectedWindowsVersion"
     }
 
-    $productVersion = (Get-Item $appPath).VersionInfo.ProductVersion
-    if (-not $productVersion.StartsWith($expectedWindowsVersion)) {
-        throw "Executable ProductVersion is $productVersion, expected $expectedWindowsVersion"
+    $versionInfo = (Get-Item $appPath).VersionInfo
+    $fileVersion = "$($versionInfo.FileMajorPart).$($versionInfo.FileMinorPart).$($versionInfo.FileBuildPart)"
+    if ($fileVersion -ne $expectedWindowsVersion) {
+        throw "Executable FileVersion is $fileVersion, expected $expectedWindowsVersion"
     }
 
     $uninstall = Start-Process -FilePath $uninstallerPath -ArgumentList '/S' -Wait -PassThru


### PR DESCRIPTION
## Summary

- build the macOS release job with Go 1.24.x so Wails and application Mach-O binaries receive `LC_UUID` metadata by default
- verify the installed Wails CLI can execute and exposes a UUID before packaging starts
- resolve Linux artifact paths before passing them to Docker and verify the WebKitGTK 4.1 package on Debian 13
- validate the Windows executable through its fixed numeric file-version resource instead of the empty localized `ProductVersion` string
- document the macOS-specific Go 1.24+ and Node 22.13+ toolchain requirements

## Context

The first 1.3.0 development release run exposed three independent verification failures:

- macOS: Wails built with Go 1.22 had no `LC_UUID`, so current dyld aborted it
- Linux: Docker interpreted the relative artifact directory as an invalid named volume
- Windows: the built and installed EXE contained `1.3.0`, but PowerShell returned an empty localized `ProductVersion`; the fixed version fields remain available

Failed run: https://github.com/Sheyiyuan/Half-Beat-Player/actions/runs/29745183881

## Validation

- release workflow YAML parsed successfully
- frontend typecheck and lint
- 34 frontend test files / 107 tests
- Vite production build
- Go 1.24.4 test and vet
- downloaded release artifact inspected: installer EXE matches uploaded EXE and contains `ProductVersion=1.3.0`
- shell syntax and `git diff --check`

The Mach-O UUID guard and cross-platform installer checks will run in the next `main` development release. Local Docker installation could not complete because this environment timed out reaching Docker Hub.