### PR TITLE
fix: make package smoke tests deterministic

### DIFF
--- a/scripts/smoke-test-macos.sh
+++ b/scripts/smoke-test-macos.sh
@@ -4,22 +4,32 @@ set -euo pipefail
 APP_PATH=${1:-build/bin/half-beat.app}
 [[ -f "$APP_PATH/Contents/Info.plist" ]] || { echo "Invalid app bundle: $APP_PATH" >&2; exit 1; }
 
-open -n -W "$APP_PATH" &
-launcher_pid=$!
+APP_EXECUTABLE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_PATH/Contents/Info.plist")
+APP_BINARY="$APP_PATH/Contents/MacOS/$APP_EXECUTABLE"
+[[ -x "$APP_BINARY" ]] || { echo "App executable is missing: $APP_BINARY" >&2; exit 1; }
+
+app_pid=""
 
 cleanup() {
-  osascript -e 'tell application id "com.sheyiyuan.half-beat" to quit' >/dev/null 2>&1 || true
-  wait "$launcher_pid" 2>/dev/null || true
+  if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
+    kill "$app_pid" 2>/dev/null || true
+    for _ in {1..10}; do
+      kill -0 "$app_pid" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -9 "$app_pid" 2>/dev/null || true
+  fi
+  [[ -z "$app_pid" ]] || wait "$app_pid" 2>/dev/null || true
 }
 trap cleanup EXIT
 
+"$APP_BINARY" &
+app_pid=$!
+
 sleep 10
-if ! kill -0 "$launcher_pid" 2>/dev/null; then
+if ! kill -0 "$app_pid" 2>/dev/null; then
   echo "macOS app exited during GUI launch smoke test" >&2
   exit 1
 fi
-
-running=$(osascript -e 'application id "com.sheyiyuan.half-beat" is running')
-[[ "$running" == "true" ]] || { echo "macOS application process is not running" >&2; exit 1; }
 
 echo "macOS GUI launch smoke test passed."

--- a/scripts/verify-linux-packages.sh
+++ b/scripts/verify-linux-packages.sh
@@ -15,7 +15,7 @@ docker run --rm \
   sh -euc '
     apt-get update
     apt-get install -y "/packages/'"$(basename "$DEB_PATH")"'"
-    dpkg-query -W -f="${Status}\n" half-beat | grep -q "install ok installed"
+    dpkg -s half-beat | grep -q "^Status: install ok installed$"
     ! ldd /usr/bin/half-beat | grep -q "not found"
     apt-get remove -y half-beat
   '


### PR DESCRIPTION
## Summary

- launch the macOS bundle executable directly and track its PID instead of resolving an uninstalled bundle through AppleScript
- bound macOS cleanup to five seconds before force termination, preventing `open -W` from hanging the job
- verify Debian installation status with `dpkg -s` so `sh -u` cannot expand `${Status}` as an unset shell parameter

## Context

The second 1.3.0 preview run successfully built all platform artifacts and passed the Windows installer test. Two verification scripts then failed:

- macOS: the app process launched, but `application id "com.sheyiyuan.half-beat"` could not resolve the temporary build bundle; cleanup subsequently blocked waiting for the running app
- Linux: Debian installed the package successfully, then the shell expanded the dpkg format token as an unset `Status` variable

Failed run: https://github.com/Sheyiyuan/Half-Beat-Player/actions/runs/29748460655

## Validation

- Bash syntax checks for both scripts
- `git diff --check`
- release log confirms the macOS application remained alive until runner cleanup
- release log confirms Debian 13 installed the package and all WebKitGTK 4.1 dependencies successfully

Full macOS, Debian, and Fedora verification will run after merge on the next development release.